### PR TITLE
feat: run channel update API calls concurrently with asyncio

### DIFF
--- a/playlist_updates.py
+++ b/playlist_updates.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import argparse
+import asyncio
 import operator
 import os
 import sys
@@ -62,6 +63,7 @@ YOUTUBE_API_VERSION = 'v3'
 DAILY_QUOTA = 10_000
 INSERT_COST = 50
 MAX_INSERTS_PER_RUN = int(DAILY_QUOTA * 0.8 / INSERT_COST)  # 160
+INSERT_CONCURRENCY = 10
 
 VideoInfo = namedtuple('VideoInfo', ['channel_id', 'published_date', 'duration'])
 JsonType = Dict[str, Any]
@@ -217,6 +219,28 @@ class YoutubeManager:
 
         return videos
 
+    async def fetch_all_channels_videos(
+        self, channels: List[Dict[str, str]], uploaded_after: arrow.Arrow, uploaded_until: Optional[arrow.Arrow]
+    ) -> List[JsonType]:
+        """Fetch each channel's recent videos concurrently.
+
+        Fetching is a pure read with no ordering requirement, so channels are processed in parallel. A failure on
+        any channel aborts the whole batch: a partial channel set must never reach the insert phase, since that
+        would let `last_updated` advance past videos we never actually looked at.
+        """
+        tasks = [
+            asyncio.to_thread(self.fetch_channel_videos, channel['id'], uploaded_after, uploaded_until)
+            for channel in channels
+        ]
+
+        all_videos: List[JsonType] = []
+        for task in tqdm(asyncio.as_completed(tasks), total=len(tasks), unit='channel'):
+            channel_videos = await task
+            channel_videos.sort(key=lambda v: v['published_at'])
+            all_videos.extend(channel_videos)
+
+        return all_videos
+
     def add_video_to_watch_later(self, video_id: JsonType) -> None:
         print(f"Adding video to playlist: {video_id['title']}")
         if not self.dry_run:
@@ -235,6 +259,24 @@ class YoutubeManager:
                     print('Already in list, skipping!')
                 else:
                     raise
+
+    async def insert_videos_watch_later(self, videos: List[JsonType]) -> None:
+        """Insert videos concurrently, bounded to INSERT_CONCURRENCY in flight at once.
+
+        Insert order doesn't affect correctness: playlist position is set later by `sort`, not by insert order.
+        A hard failure on any video aborts the whole batch (in-flight siblings may finish or not, that's fine) so
+        that `update()` never mints `last_updated` for a partially-inserted batch; the next run retries the full
+        batch, tolerating re-inserts via the existing 409-skip handling above.
+        """
+        semaphore = asyncio.Semaphore(INSERT_CONCURRENCY)
+
+        async def insert_one(video: JsonType) -> None:
+            async with semaphore:
+                await asyncio.to_thread(self.add_video_to_watch_later, video)
+
+        tasks = [insert_one(video) for video in videos]
+        for task in tqdm(asyncio.as_completed(tasks), total=len(tasks), unit='video'):
+            await task
 
     def update(
         self,
@@ -265,11 +307,11 @@ class YoutubeManager:
             write_config(config)
 
         allowed_channels = [i for i in channels if i['id'] in allowed_channel_ids]
-        all_videos = []
-        for channel in tqdm(allowed_channels, unit='channel'):
-            channel_videos = self.fetch_channel_videos(channel['id'], uploaded_after, uploaded_until)
-            channel_videos.sort(key=lambda v: v['published_at'])
-            all_videos.extend(channel_videos)
+        all_videos = (
+            asyncio.run(self.fetch_all_channels_videos(allowed_channels, uploaded_after, uploaded_until))
+            if allowed_channels
+            else []
+        )
 
         effective_until = uploaded_until
         if auto_batch and len(all_videos) > MAX_INSERTS_PER_RUN:
@@ -282,8 +324,8 @@ class YoutubeManager:
                 f' through {effective_until}. {remaining} remaining.'
             )
 
-        for video in tqdm(all_videos, unit='video'):
-            self.add_video_to_watch_later(video)
+        if all_videos:
+            asyncio.run(self.insert_videos_watch_later(all_videos))
 
         if not self.dry_run:
             config['last_updated'] = effective_until.format() if effective_until else arrow.now().format()


### PR DESCRIPTION
Scanning many subscriptions and inserting their recent uploads ran fully
serially, so the update command's wall-clock time scaled linearly with
subscription and video count. Both phases are now concurrent:

- Fetching each channel's recent videos is a pure read with no ordering
  requirement, so channels are fetched in parallel via asyncio.to_thread.
- Inserting videos into the watch-later playlist is bounded to 10
  concurrent requests (INSERT_CONCURRENCY) via an asyncio.Semaphore, since
  insert order has no effect on final playlist position (that's set later
  by the sort command) but unbounded concurrency risks tripping the
  YouTube API's short-window rate limiting.

A failure in either phase aborts the whole run before last_updated is
written, matching the existing serial behavior: a partial fetch or insert
must never be treated as a completed batch, since that would silently
skip videos on the next run. The next run simply retries the full batch,
tolerating repeat inserts via the existing 409-skip handling.